### PR TITLE
HUK24 ohne eid ab 09.10.17

### DIFF
--- a/_data/versicherungen.yml
+++ b/_data/versicherungen.yml
@@ -123,7 +123,6 @@ websites:
   facebook: HUKCOBURG
   img: huk24.png
   tfa: "Yes"
-  eid: Yes
 
 - name: HUK Coburg 
   url: https://www.huk.de/login.do#


### PR DESCRIPTION
Die HUK24 stellt die Anmeldung mit elektronischem Personalausweis zum 09.10.2017 laut Kundenmail vom 26.09.2017 ein. Danach ist eine Anmeldung nur noch mit einem Faktor möglich.